### PR TITLE
Use longer jump in riscv/crt0.S

### DIFF
--- a/crt/arch/riscv/crt0.S
+++ b/crt/arch/riscv/crt0.S
@@ -32,10 +32,10 @@ _start:
 .option pop
 
 	li s0, 0
-	li ra, 0
 
 	addi  a0, sp, 0
-	jal  ra, __sel4_start_c
+	la x5, __sel4_start_c
+	jalr ra, x5, 0
 
 	/* should not return */
 1:


### PR DESCRIPTION
Simple `jal` fails to link when seL4 is built with user API functions defined as public in https://github.com/seL4/seL4/blob/master/libsel4/CMakeLists.txt#L13

The exact error message is:

```
sel4test2/projects/sel4runtime/crt/arch/riscv/crt0.S:38:(.text+0xe): relocation truncated to fit: R_RISCV_JAL against symbol '__sel4_start_c' defined in .text section in apps/sel4test-driver/sel4runtime/libsel4runtime.a(crt1.c.obj)
```