### PR TITLE
lld: Fix .tdata/.tbss addresses when .tdata is empty

### DIFF
--- a/src/start_root.c
+++ b/src/start_root.c
@@ -19,6 +19,7 @@
 
 extern unsigned int _tdata_start[];
 extern unsigned int _tdata_end[];
+extern unsigned int _tbss_start[];
 extern unsigned int _tbss_end[];
 
 long sel4_vsyscall(long sysnum, ...);
@@ -37,7 +38,23 @@ void __sel4_start_root(seL4_BootInfo *boot_info)
 {
     sel4runtime_uintptr_t tdata_start = (sel4runtime_uintptr_t) &_tdata_start[0];
     sel4runtime_uintptr_t tdata_end = (sel4runtime_uintptr_t) &_tdata_end[0];
+    sel4runtime_uintptr_t tbss_start = (sel4runtime_uintptr_t) &_tbss_start[0];
     sel4runtime_uintptr_t tbss_end = (sel4runtime_uintptr_t) &_tbss_end[0];
+
+    /* Unlike ld.bfd, lld assigns 0 address to empty .tdata output
+     * sections and its linker variables. This will make
+     * _tdata_start and _tdata_end zero.
+     * Assuming _tdata_end in this code to be adjacent to _tbss_start would be
+     * wrong and will trigger address faults as the TLS'
+     * region p_memsz value will be wrong.
+     * Assigning empty tbss_start to tdata[_start|_end] will
+     * follow ld.bfd and results in the proper 0 p_memsz.
+     * The .tdata section is empty and hence, the linker script variables are zero
+     */
+    if (tdata_start == 0) {
+        tdata_start = tbss_start;
+        tdata_end = tbss_start;
+    }
 
     Elf_Phdr tls_header = {
         .p_type   = PT_TLS,


### PR DESCRIPTION
Unliked ld.bfd, lld assigns 0 address to empty output sections and its linker variables. This will make
_tdata_start and _tdata_end zero. Assuming _tdata_end in this code to be adjacent to _tbss_start would be wrong and will trigger address faults as the TLS'
region p_memsz value will be wrong.

Assigning empty tbss_start to tdata[_start|_end] will follow ld.bfd and results in the proper 0 p_memsz.

Sponsored by: DARPA.