### PR TITLE
CI: simulation and HW build with LLVM on RISCV

### DIFF
--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -21,11 +21,6 @@ jobs:
       matrix:
         march: [armv7a, armv8a, nehalem, rv32imac, rv64imac]
         compiler: [gcc, clang]
-        exclude:
-          - march: rv32imac
-            compiler: clang
-          - march: rv64imac
-            compiler: clang
     steps:
     - uses: seL4/ci-actions/sel4test-sim@master
       with:


### PR DESCRIPTION
Similar to https://github.com/seL4/seL4/pull/1154, pick up things from https://github.com/seL4/ci-actions/pull/297