### PR TITLE
Add AT_PAGESZ to _sel4_start auxv

### DIFF
--- a/include/sel4runtime/auxv.h
+++ b/include/sel4runtime/auxv.h
@@ -12,6 +12,7 @@
 #define AT_PHDR      3
 #define AT_PHENT     4
 #define AT_PHNUM     5
+#define AT_PAGESZ    6
 #define PT_TLS       7
 #define PT_NUM       8
 #define AT_SYSINFO  32

--- a/src/start_root.c
+++ b/src/start_root.c
@@ -69,7 +69,7 @@ void __sel4_start_root(seL4_BootInfo *boot_info)
     struct {
         char const *const argv[2];
         char const *const envp[2];
-        auxv_t auxv[7];
+        auxv_t auxv[8];
     } info = {
         .argv = {
             "rootserver",
@@ -98,6 +98,9 @@ void __sel4_start_root(seL4_BootInfo *boot_info)
             }, {
                 .a_type = AT_SEL4_TCB,
                 .a_un.a_val = seL4_CapInitThreadTCB,
+            }, {
+                .a_type = AT_PAGESZ,
+                .a_un.a_val = 0x1000,
             }, {
                 // Null terminating entry
                 .a_type = AT_NULL,


### PR DESCRIPTION
Add an entry to the bootstrap auxv describing the page size as 4k. This entry tells the runtime system the default base page size of the environment.

Elsewhere, in libsel4utils, AT_PAGESZ is used when launching new processes and sets the page size to 4k.